### PR TITLE
Add workflow to release to NPM

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -1,0 +1,41 @@
+# This workflow will install Deno then run Deno lint and test.
+# For more information see: https://github.com/denoland/setup-deno
+
+name: Release to NPM
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+
+      - name: setup deno
+        # uses: denoland/setup-deno@v1
+        uses: denoland/setup-deno@004814556e37c54a2f6e31384c9e18e983317366
+        with:
+          deno-version: v1.x
+
+      - name: Get Version
+        id: vars
+        run: echo ::set-output name=version::$(echo ${{github.ref_name}} | sed 's/^v//')
+
+      - name: Build
+        run: deno task npm:build
+        env:
+          NPM_VERSION: ${{steps.vars.outputs.version}}
+
+      - name: Publish
+        run: npm publish --access=public
+        working-directory: ./npm
+        env:
+          NPM_AUTH_TOKEN: ${{env.NPM_TOKEN}}


### PR DESCRIPTION
## Motivation
We want to publish this package to both deno.land/x and npmjs.com

## Approach
For deno, it's as simple as pushing a release tag to the repo and boom, it's on deno.land/x. For NPM, we need to build and publish to npmjs.com

This updates the npm build script to draw its version from the `NPM_VERSION` environment variable so that it can take it dynamically.

Then, we add a workflow for new tags starting with `v` like `v1.0.0` which then extracts out the number (in this case
`1.0.0`) from the tag and then uses it to set an output variable. This can be used to set the NPM_VERSION variable in the build.