### PR TITLE
accept NPM_VERSION variable in npm build

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -38,4 +38,4 @@ jobs:
         run: npm publish --access=public
         working-directory: ./npm
         env:
-          NPM_AUTH_TOKEN: ${{env.NPM_TOKEN}}
+          NODE_AUTH_TOKEN: ${{env.NPM_TOKEN}}

--- a/npm.ts
+++ b/npm.ts
@@ -1,6 +1,9 @@
 import { build, emptyDir } from "https://deno.land/x/dnt@0.17.0/mod.ts";
-
+import { assert } from "./t/asserts.ts";
 await emptyDir("./npm");
+
+let version = Deno.env.get("NPM_VERSION");
+assert(version, "NPM_VERSION is required to build npm package");
 
 await build({
   entryPoints: ["./mod.ts"],
@@ -17,7 +20,7 @@ await build({
   package: {
     // package.json properties
     name: "@frontside/continuation",
-    version: "0.1.2",
+    version,
     description: "Delimited continuations for JavaScript",
     license: "MIT",
     repository: {


### PR DESCRIPTION
## Motivation
The release workflow depends on accepting a dynamic version, but I forgot to add it.

## Approach
- use the environment variable
- use NODE_AUTH_TOKEN, not NPM_AUTH_TOKEN