### PR TITLE
Convert to BDD style tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Changelog
 
+- migrate from Deno.test to BDD https://deno.com/blog/v1.21#bdd-style-testing
+
 ## \[0.1.4]
 
 - now that automatic cross releasing is working for both deno.land/x and
-npmjs.org, this has both release matching the exact same commit.
+  npmjs.org, this has both release matching the exact same commit.
 
 ## \[0.1.3]
 

--- a/t/bdd.ts
+++ b/t/bdd.ts
@@ -1,0 +1,1 @@
+export * from "https://deno.land/std@0.136.0/testing/bdd.ts";


### PR DESCRIPTION
## Motivation
With Deno 1.21 came the introduction of BDDD style unit tests. This
flows more naturally and is in line with all our other test suites.

## Approach
This converts to the new [syntax]

[syntax]: https://deno.com/blog/v1.21#bdd-style-testing