### PR TITLE
🐛 oneshot continuation should throw the same error consistently

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -57,11 +57,20 @@ export function evaluate<T>(block: () => Computation, getNext = $next()): T {
 
 function oneshot<T, R>(fn: Continuation<T, R>): Continuation<T, R> {
   let continued = false;
+  let failure: { error: unknown };
   let result: any;
+
   return ((value) => {
     if (!continued) {
       continued = true;
-      return result = fn(value);
+      try {
+        return result = fn(value);
+      } catch (error) {
+        failure = { error };
+        throw error;
+      }
+    } else if (failure) {
+      throw failure.error;
     } else {
       return result;
     }

--- a/t/continuation.test.ts
+++ b/t/continuation.test.ts
@@ -1,5 +1,5 @@
 import { describe, it } from "./bdd.ts";
-import { assertEquals } from "./asserts.ts";
+import { assertEquals, assertThrows } from "./asserts.ts";
 import { Computation, evaluate, K, reset, shift } from "../mod.ts";
 
 describe("continuation", () => {
@@ -67,16 +67,8 @@ describe("continuation", () => {
       throw new Error(`bing ${++bing}`);
     });
 
-    try {
-      boom();
-    } catch (e) {
-      assertEquals("bing 1", e.message);
-    }
-    try {
-      boom();
-    } catch (e) {
-      assertEquals("bing 1", e.message);
-    }
+    assertThrows(boom, Error, "bing 1");
+    assertThrows(boom, Error, "bing 1");
   });
 
   it("can exit early from  recursion", () => {


### PR DESCRIPTION
## Motivation
It turns out that there was a bug with the `oneshot()` logic, where if an error was raised, then the next time, the continuation would successfully return undefined. This was not being caught because the test case was broken (It did not check that the `boom()` continuation failed, only that if it did, the message of the exception was the same,

## Approach
This fixes the test, and then in the event of a failure, saves the error (much in the same way that the result is saved) and then subsequent calls to this function will raise the exact same exception.

### Alternate Designs

We could leave it as-is, because it doesn't seem to be causing any problems, but it seems like the symmetric case of resolution and rejection should be handled the same. If the continuation caches the result, then it should also cache the exception.