### PR TITLE
prevent stack overflows with `k.tail()`

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -1,11 +1,25 @@
 // deno-lint-ignore-file no-explicit-any
 
+interface Thunk {
+  method: "next" | "throw";
+  iterator: Iterator<Control, unknown, unknown>;
+  value?: unknown | Error;
+}
+
+interface Stack {
+  reducing: boolean;
+  push(...thunks: Thunk[]): number;
+  pop(): Thunk | undefined;
+  value?: any;
+}
+
 export interface Computation<T = any> {
   [Symbol.iterator](): Iterator<Control, T, any>;
 }
 
 export interface Continuation<T = any, R = any> {
   (value: T): R;
+  tail(value: T): void;
 }
 
 export function* reset<T>(block: () => Computation): Computation<T> {
@@ -18,44 +32,130 @@ export function* shift<T>(
   return yield { type: "shift", block };
 }
 
-export function evaluate<T>(block: () => Computation, getNext = $next()): T {
-  let stack = [block()];
-  let value: any;
-  for (let current = stack.pop(); current; current = stack.pop()) {
-    let prog = current[Symbol.iterator]();
-    try {
-      let next = getNext(prog);
-      getNext = (iter) => iter.next(value);
-      if (next.done) {
-        value = next.value;
-      } else {
-        let cont = ({ [Symbol.iterator]: () => prog });
-        let control = next.value;
-        if (control.type === "reset") {
-          stack.push(cont);
-          stack.push(control.block());
-        } else {
-          let resolve: Continuation = oneshot((value) =>
-            evaluate(() => cont, $next(value))
-          );
-          let reject: Continuation<Error> = oneshot((error) =>
-            evaluate(() => cont, $throw(error))
-          );
-          stack.push(control.block(resolve, reject));
-        }
-      }
-    } catch (error) {
-      if (!stack.length) {
-        throw error;
-      } else {
-        getNext = $throw(error);
-      }
-    }
-  }
-  return value;
+function createStack(): Stack {
+  let list: Thunk[] = [];
+  return {
+    reducing: false,
+    push(...thunks: Thunk[]): number {
+      return list.push(...thunks);
+    },
+    pop(): Thunk | undefined {
+      return list.pop();
+    },
+  };
 }
 
-function oneshot<T, R>(fn: Continuation<T, R>): Continuation<T, R> {
+export function evaluate<T>(iterator: () => Computation): T {
+  let stack = createStack();
+  stack.push({
+    method: "next",
+    iterator: iterator()[Symbol.iterator](),
+  });
+  return reduce(stack);
+}
+
+function reduce<T>(stack: Stack): T {
+  try {
+    stack.reducing = true;
+    for (let current = stack.pop(); current; current = stack.pop()) {
+      try {
+        let next = getNext(current);
+        stack.value = next.value;
+
+        if (!next.done) {
+          let control = next.value;
+          if (control.type === "reset") {
+            stack.push(
+              {
+                ...current,
+                method: "next",
+                get value() {
+                  return stack.value;
+                },
+              },
+              {
+                method: "next",
+                iterator: control.block()[Symbol.iterator](),
+              },
+            );
+          } else {
+            let thunk = current;
+            let resolve = oneshot((value: unknown) => {
+              stack.push({
+                method: "next",
+                iterator: thunk.iterator,
+                value,
+              });
+              return reduce(stack);
+            });
+            resolve.tail = oneshot((value: unknown) => {
+              stack.push({
+                method: "next",
+                iterator: thunk.iterator,
+                value,
+              });
+              if (!stack.reducing) {
+                reduce(stack);
+              }
+            });
+            let reject = oneshot((error: Error) => {
+              stack.push({
+                method: "throw",
+                iterator: thunk.iterator,
+                value: error,
+              });
+              return reduce(stack);
+            });
+            reject.tail = oneshot((error: Error) => {
+              stack.push({
+                method: "throw",
+                iterator: thunk.iterator,
+                value: error,
+              });
+
+              if (!stack.reducing) {
+                reduce(stack);
+              }
+            });
+
+            stack.push({
+              method: "next",
+              iterator: control.block(resolve, reject)[Symbol.iterator](),
+              value: void 0,
+            });
+          }
+        }
+      } catch (error) {
+        let top = stack.pop();
+        if (top) {
+          stack.push({ ...top, method: "throw", value: error });
+        } else {
+          throw error;
+        }
+      }
+    }
+  } finally {
+    stack.reducing = false;
+  }
+
+  return stack.value;
+}
+
+function getNext(thunk: Thunk) {
+  let { iterator } = thunk;
+  if (thunk.method === "next") {
+    return iterator.next(thunk.value);
+  } else {
+    let value = thunk.value as Error;
+    if (iterator.throw) {
+      return iterator.throw(value);
+    } else {
+      throw value;
+    }
+  }
+}
+
+function oneshot<T, R>(fn: (t: T) => R): Continuation<T, R> {
   let continued = false;
   let failure: { error: unknown };
   let result: any;
@@ -64,7 +164,7 @@ function oneshot<T, R>(fn: Continuation<T, R>): Continuation<T, R> {
     if (!continued) {
       continued = true;
       try {
-        return result = fn(value);
+        return (result = fn(value));
       } catch (error) {
         failure = { error };
         throw error;
@@ -76,16 +176,6 @@ function oneshot<T, R>(fn: Continuation<T, R>): Continuation<T, R> {
     }
   }) as Continuation<T, R>;
 }
-
-const $next = (value?: any) => (i: Iterator<Control>) => i.next(value);
-const $throw = (error: Error) =>
-  (i: Iterator<Control>) => {
-    if (i.throw) {
-      return i.throw(error);
-    } else {
-      throw error;
-    }
-  };
 
 export type K<T = any, R = any> = Continuation<T, R>;
 

--- a/t/continuation.test.ts
+++ b/t/continuation.test.ts
@@ -103,4 +103,17 @@ describe("continuation", () => {
     assertEquals("function", typeof k);
     assertEquals(10, k(5));
   });
+
+  it("can withstand stack overflow", () => {
+    function* run() {
+      for (let i = 0; i < 100_000; i++) {
+        yield* shift(function* (k) {
+          k.tail(1);
+        });
+      }
+    }
+
+    evaluate(run);
+    assertEquals(true, true);
+  });
 });


### PR DESCRIPTION
## Motivation

The goal of this PR is to prevent stack overflows which required a change to the architecture for how `evaluate()` operates.  Previously inside a `shift()` instruction we would always return the value of `k()`.  This caused another tick in the stack frame which caused the stack to increase until an overflow was reached.  Previously it only took about 1495 `shift()` calls inside a loop to cause a stack overflow.  

Now we provide the ability for the end-user to decide whether or not they care about the return value of `k()` with the addition of `k.tail()` which will continue the same stack frame instead of creating a new one preventing the likely-hood of a stack overflow.

The reason why I started investigating this inside `continuation` was because of a previous issue in `redux-saga`: https://github.com/redux-saga/redux-saga/issues/1592

Pertinent test case:

```ts
it("can withstand stack overflow", () => {
    function* run() {
      for (let i = 0; i < 1_000_000; i++) { // also tested at 10_000_000 which passed
        yield* shift(function* (k) {
          k.tail(1);
        });
      }
    }

    evaluate(run);
    assertEquals(true, true);
  });
```

## Approach

The primary approach was to change how the continuation loop worked.  Instead of having a stack hold an array of `Computation` we instead store an array of `Thunk` where a thunk is either a) `next` or b) `throw` which inform the while-loop whether to call `iter.next` or `iter.throw`.  This explicit `Thunk` driver allows us to better control what the loop is doing and allowed us to cleanly separate the `Thunk` instructions from the `Control` instructions.

### Alternate Designs

 <!-- OPTIONAL
   Explain what other alternatives you considered and why you chose this option.
 -->

### Possible Drawbacks or Risks

The primary drawback is the end-user needs to know whether or not to use `k()` or `k.throw()`.  This also doesn't solve what happens when a user hits a stack overflow -- which usually just silently crashes their app.
