### PR TITLE
Add a link to wikipedia page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Continuation
 
-Delimited continuations for JavaScript
+[Delimited continuations])(https://en.wikipedia.org/wiki/Delimited_continuation) for JavaScript
 
 ## Install
 


### PR DESCRIPTION
## Motivation

I'm referencing this page in Effection docs, so I want to ensure that it provides a trail to the definition of Delimited Continuation.

## Approach

Markdown 💪 to add a [link](https://en.wikipedia.org/wiki/Delimited_continuation) to Wikipedia
